### PR TITLE
Drop sbt-pgp from project/plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform"      % "1.3.0")
 addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "0.2.2")
-addSbtPlugin("com.jsuereth"     % "sbt-pgp"              % "1.0.0")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")


### PR DESCRIPTION
Per the official installation instructions[1], sbt-pgp should be enabled
via ~/.sbt/0.13/plugins/gpg.sbt, rather than a project-local
configuration:

> Installation
> For sbt 0.13.5+:
>
> Add the following to your ~/.sbt/0.13/plugins/gpg.sbt file:
>
> addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

Fixes #15

[1] http://www.scala-sbt.org/sbt-pgp/