### PR TITLE
Remove leading blank line when generating run script

### DIFF
--- a/src/main/scala/org/scalatra/sbt/DistPlugin.scala
+++ b/src/main/scala/org/scalatra/sbt/DistPlugin.scala
@@ -46,16 +46,14 @@ object DistPlugin extends Plugin {
   }
 
   private def createScriptString(base: File, name: String, libFiles: Seq[File], mainClass: Option[String], javaOptions: Seq[String], envExports: Seq[String]): String = {
-    """
-|#!/bin/env bash
-|
-|export CLASSPATH="lib:%s"
-|export JAVA_OPTS="%s"
-|%s
-|
-|java $JAVA_OPTS -cp $CLASSPATH %s
-|
-""".stripMargin.format(classPathString(base, libFiles), javaOptions.mkString(" "), envExports.map(e => "export %s".format(e)).mkString("\n"), mainClass.getOrElse(""))
+    """#!/bin/env bash
+      |
+      |export CLASSPATH="lib:%s"
+      |export JAVA_OPTS="%s"
+      |%s
+      |
+      |java $JAVA_OPTS -cp $CLASSPATH %s
+      |""".stripMargin.format(classPathString(base, libFiles), javaOptions.mkString(" "), envExports.map(e => "export %s".format(e)).mkString("\n"), mainClass.getOrElse(""))
   }
 
   private def classPathString(base: File, libFiles: Seq[File]) = {


### PR DESCRIPTION
Some programs, such as `start-stop-deamon` expect the very
first line of the script to contain the shebang.  These programs
fail to run the script as generated by DistPlugin as it
is currently adding a leading blank line with the shebang on
the second line.

This fixes the issue by eliminating the blank line when
generating the run script.