### PR TITLE
Explicit activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ enablePlugins(DistPlugin)
 
 Execute the task as follows with the sbt shell, distribution file (zip) will be created.
 
+```
+> dist
+```

--- a/src/main/scala/org/scalatra/sbt/ScalatraPlugin.scala
+++ b/src/main/scala/org/scalatra/sbt/ScalatraPlugin.scala
@@ -11,7 +11,6 @@ import com.earldouglas.xwp.JettyPlugin.autoImport.Jetty
 
 object ScalatraPlugin extends AutoPlugin {
   override def requires = JettyPlugin
-  override def trigger  = allRequirements
 
   val autoImport = PluginKeys
 

--- a/src/main/scala/org/scalatra/sbt/WarOverlayPlugin.scala
+++ b/src/main/scala/org/scalatra/sbt/WarOverlayPlugin.scala
@@ -10,7 +10,6 @@ import com.earldouglas.xwp.JettyPlugin.autoImport.Jetty
 
 object WarOverlayPlugin extends AutoPlugin {
   override def requires = JettyPlugin
-  override def trigger  = allRequirements
 
   object Keys {
     val overlayWars = taskKey[Seq[File]]("Import the files from referenced wars")


### PR DESCRIPTION
scalatra-sbt contains a number of plug-ins,
it is better to explicitly enable the necessary ones.