### PR TITLE
rename from 'scalatra-sbt' to 'sbt-scalatra'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-scalatra-sbt
+sbt-scalatra
 ============
 
 [![Build Status](https://travis-ci.org/scalatra/scalatra-sbt.svg)](https://travis-ci.org/scalatra/scalatra-sbt)
@@ -8,7 +8,7 @@ An sbt plugins set for Scalatra application development.
 Add the plugin in `project/plugins.sbt`
 
 ```scala
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "1.0.0")
+addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.0")
 ```
 
 ## ScalatraPlugin

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).settings(
   organization := "org.scalatra.sbt",
-  name := "scalatra-sbt",
+  name := "sbt-scalatra",
   sbtPlugin := true,
   version := "1.0.0",
   crossSbtVersions := Seq("0.13.16", "1.0.2"),

--- a/src/sbt-test/DistPlugin/dist/build.sbt
+++ b/src/sbt-test/DistPlugin/dist/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-dist-test"
+name := "sbt-scalatra-dist-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.2"
 

--- a/src/sbt-test/DistPlugin/dist/project/plugin.sbt
+++ b/src/sbt-test/DistPlugin/dist/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/src/sbt-test/DistPlugin/dist/test
+++ b/src/sbt-test/DistPlugin/dist/test
@@ -2,4 +2,4 @@
 
 > dist
 
-$ exists target/scalatra-sbt-dist-test-0.1.0-SNAPSHOT.zip
+$ exists target/sbt-scalatra-dist-test-0.1.0-SNAPSHOT.zip

--- a/src/sbt-test/JRebelPlugin/generateJRebel/build.sbt
+++ b/src/sbt-test/JRebelPlugin/generateJRebel/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-jrebel-test"
+name := "sbt-scalatra-jrebel-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.2"
 

--- a/src/sbt-test/JRebelPlugin/generateJRebel/project/plugin.sbt
+++ b/src/sbt-test/JRebelPlugin/generateJRebel/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/src/sbt-test/ScalatraPlugin/browse/build.sbt
+++ b/src/sbt-test/ScalatraPlugin/browse/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-browse-test"
+name := "sbt-scalatra-browse-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.3"
 

--- a/src/sbt-test/ScalatraPlugin/browse/project/plugin.sbt
+++ b/src/sbt-test/ScalatraPlugin/browse/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/src/sbt-test/ScalatraPlugin/container-start/build.sbt
+++ b/src/sbt-test/ScalatraPlugin/container-start/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-container-start-test"
+name := "sbt-scalatra-container-start-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.3"
 

--- a/src/sbt-test/ScalatraPlugin/container-start/project/plugin.sbt
+++ b/src/sbt-test/ScalatraPlugin/container-start/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/src/sbt-test/ScalatraPlugin/jetty-start/build.sbt
+++ b/src/sbt-test/ScalatraPlugin/jetty-start/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-jetty-start-test"
+name := "sbt-scalatra-jetty-start-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.2"
 

--- a/src/sbt-test/ScalatraPlugin/jetty-start/project/plugin.sbt
+++ b/src/sbt-test/ScalatraPlugin/jetty-start/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }

--- a/src/sbt-test/WarOverlayPlugin/overlayWars/build.sbt
+++ b/src/sbt-test/WarOverlayPlugin/overlayWars/build.sbt
@@ -1,5 +1,5 @@
 organization := "org.scalatra"
-name := "scalatra-sbt-overlaywars-test"
+name := "sbt-scalatra-overlaywars-test"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.12.2"
 

--- a/src/sbt-test/WarOverlayPlugin/overlayWars/project/plugin.sbt
+++ b/src/sbt-test/WarOverlayPlugin/overlayWars/project/plugin.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.15.9a"
 
 sys.props.get("plugin.version") match {
-  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % x)
+  case Some(x) => addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }


### PR DESCRIPTION
see 'Follow the naming conventions'

http://www.scala-sbt.org/1.0/docs/Plugins-Best-Practices.html

I modified it except where it depends on the path of the GitHub repository.